### PR TITLE
Tie handling

### DIFF
--- a/rift/node.py
+++ b/rift/node.py
@@ -1773,13 +1773,12 @@ class Node:
         if self.is_same_level_tie(tie_packet):
             self.peer_node_tie_packet_infos[tie_packet.header.tieid] = tie_packet_info
             self.update_partially_conn_all_intfs()
-            self.regenerate_my_south_prefix_tie()
-            
-        if self.top_of_fabric() and tie_type == common.ttypes.TIETypeType.NegativeDisaggregationPrefixTIEType:
+            self.regenerate_my_south_prefix_tie()   
+        if tie_packet.header.level == self.level_value + 1 and \
+            tie_type == common.ttypes.TIETypeType.NegativeDisaggregationPrefixTIEType:
             trigger_spf = True
             reason = "TIE " + packet_common.tie_id_str(tie_id) + " added negative"
-            if self.is_same_level_tie(tie_packet):
-                update_neg_disagg_propagation()
+            update_neg_disagg_propagation()
         if trigger_spf:
             self.trigger_spf(reason)
 

--- a/rift/node.py
+++ b/rift/node.py
@@ -1773,12 +1773,12 @@ class Node:
         if self.is_same_level_tie(tie_packet):
             self.peer_node_tie_packet_infos[tie_packet.header.tieid] = tie_packet_info
             self.update_partially_conn_all_intfs()
-            self.regenerate_my_south_prefix_tie()   
+            self.regenerate_my_south_prefix_tie()
         if tie_packet.header.level == self.level_value + 1 and \
             tie_type == common.ttypes.TIETypeType.NegativeDisaggregationPrefixTIEType:
             trigger_spf = True
             reason = "TIE " + packet_common.tie_id_str(tie_id) + " added negative"
-            update_neg_disagg_propagation()
+            self.update_neg_disagg_propagation()
         if trigger_spf:
             self.trigger_spf(reason)
 

--- a/rift/node.py
+++ b/rift/node.py
@@ -1760,6 +1760,7 @@ class Node:
     def store_tie_packet_info(self, tie_packet_info):
         tie_packet = tie_packet_info.protocol_packet.content.tie
         tie_id = tie_packet.header.tieid
+        tie_type = tie_id.tietype
         if tie_id in self.tie_packet_infos:
             old_tie_packet_info = self.tie_packet_infos[tie_id]
             trigger_spf = self.ties_differ_enough_for_spf(old_tie_packet_info, tie_packet_info)
@@ -1773,6 +1774,12 @@ class Node:
             self.peer_node_tie_packet_infos[tie_packet.header.tieid] = tie_packet_info
             self.update_partially_conn_all_intfs()
             self.regenerate_my_south_prefix_tie()
+            
+        if self.top_of_fabric() and tie_type == common.ttypes.TIETypeType.NegativeDisaggregationPrefixTIEType:
+            trigger_spf = True
+            reason = "TIE " + packet_common.tie_id_str(tie_id) + " added negative"
+            if self.is_same_level_tie(tie_packet):
+                update_neg_disagg_propagation()
         if trigger_spf:
             self.trigger_spf(reason)
 


### PR DESCRIPTION
Now we check if a node needs to process negative disaggregation TIEs. This is by checking the TIE type and the level  (the next-higher level).

If the node is a TOF we just add the tie in the sorted dict tie_packet_infos but we don't call update_neg_disagg_propagation().
